### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,9 @@ jobs:
       - run: exit 1
   test:
     uses: ./.github/workflows/workflow_call_test.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: read
       pull-requests: write
+      id-token: write

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -1,11 +1,18 @@
 ---
 name: test (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 jobs:
   go:
-    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@e442a17816baa8a940edc1544cc6e739d870e165 # v5.0.2
+    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb # v6.0.0
     with:
       aqua_version: v2.51.0
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write


### PR DESCRIPTION
Introduce takumi guard (Go variant) into the CI workflows.

## Changes

- `.github/workflows/workflow_call_test.yaml`
  - Bump `go-test-full-workflow` ref `v5.0.2` -> `v6.0.0` (`98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb`).
  - Declare the reusable-workflow secret `TAKUMI_GUARD_BOT_ID` (`required: true`) under `on.workflow_call.secrets`.
  - Pass `secrets.TAKUMI_GUARD_BOT_ID` to the `go` job and add `id-token: write` to its permissions.

- `.github/workflows/test.yaml`
  - In the `test` job (which calls `./.github/workflows/workflow_call_test.yaml`), pass `secrets.TAKUMI_GUARD_BOT_ID` and add `id-token: write` to its permissions so the secret and OIDC token flow down the chain.

## Note

`go-test-full-workflow` was bumped across a MAJOR version (`v5` -> `v6`). Please review CI for any breaking changes.

The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository/organization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)